### PR TITLE
POC: Delegate the registration of abstract nodes to themselves

### DIFF
--- a/addons/brennys-game-manager/abstract_game_manager.gd
+++ b/addons/brennys-game-manager/abstract_game_manager.gd
@@ -8,20 +8,18 @@ extends Node2D
 @export var menu_container: Node
 @export var transition_container: Node
 @export var player: AbstractPlayer
-@export var main_menu: String
+@export var main_menu: AbstractMenu
 @export var levels: Array[LevelKey]
-@export var menus: Array[MenuKey]
 @export var transitions: Array[TransitionKey]
 
 var level_map: Dictionary[String, PackedScene] = {}
-var menu_map: Dictionary[String, PackedScene] = {}
+static var menu_map: Dictionary[String, AbstractMenu] = {}
 var transition_map: Dictionary[String, PackedScene] = {}
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	connect_signals()
 	prep_player()
-	map_menus()
 	map_levels()
 	map_transitions()
 	GameStateEvents.SHOW_MENU_REQUESTED.emit(main_menu)
@@ -34,11 +32,6 @@ func connect_signals() -> void:
 func prep_player() -> void:
 	player.get_parent().remove_child(player)
 
-func map_menus() -> void:
-	for menu in menus:
-		assert(menu.targetScene.instantiate() is AbstractMenu, "Only Scenes which inherit from AbstractMenu can be registered as a menu")
-		menu_map.set(menu.menuName, menu.targetScene)
-
 func map_levels() -> void:
 	for level in levels:
 		assert(level.targetScene.instantiate() is AbstractLevel, "Only Scenes which inherit from AbstractLevel can be registered as a level")
@@ -49,25 +42,14 @@ func map_transitions() -> void:
 		assert(transition.targetScene.instantiate() is AbsctractSceneTransition, "Only Scenes which inherit from AbstractSceneTransition can be registered as a Scene Transition")
 		transition_map.set(transition.transitionName, transition.targetScene)
 
-func handle_show_menu_request(requestedMenu: String) -> void:
-	assert(is_valid_menu(requestedMenu), requestedMenu + " is not a valid Menu")
-	var menu : AbstractMenu = menu_map.get(requestedMenu).instantiate()
-	self.call_deferred("_handle_menu_transition", menu)
+func handle_show_menu_request(requestedMenu: AbstractMenu) -> void:
+	requestedMenu.show()
 
 func handle_close_menu_request() -> void:
 	var menu_container_children := menu_container.get_children()
 	for child in menu_container_children:
 		child.queue_free()
 	GameStateEvents.MENU_CLOSED.emit()
-
-func is_valid_menu(requestedMenu: String) -> bool:
-	return menu_map.has(requestedMenu)
-
-func _handle_menu_transition(newMenu: AbstractMenu) -> void:
-	var menu_container_children := menu_container.get_children()
-	menu_container.call_deferred("add_child", newMenu)
-	for child in menu_container_children:
-		child.queue_free()
 
 func handle_level_change_requested(requestedLevel: String, requestedTransition: String, teleportDestination: String) -> void:
 	change_level(requestedLevel, requestedTransition, teleportDestination)

--- a/addons/brennys-game-manager/event-bus/game-state-events.gd
+++ b/addons/brennys-game-manager/event-bus/game-state-events.gd
@@ -3,7 +3,7 @@ extends Node
 @warning_ignore_start("unused_signal")
 #region Menu Related Signals
 signal SHOW_MENU_REQUESTED(
-	requestedMenu: String
+	requestedMenu: AbstractMenu
 )
 signal CLOSE_MENU_REQUESTED
 signal MENU_OPEN

--- a/addons/brennys-game-manager/menu/abstract_menu.gd
+++ b/addons/brennys-game-manager/menu/abstract_menu.gd
@@ -2,5 +2,7 @@
 class_name AbstractMenu
 extends Control
 
+@export var menu_name : StringName
+
 func _enter_tree() -> void:
 	GameStateEvents.MENU_OPEN.emit()

--- a/demo-game/game-logic/game_event_input_manager.gd
+++ b/demo-game/game-logic/game_event_input_manager.gd
@@ -1,5 +1,7 @@
 extends Node2D
 
+@export var pause_menu : AbstractMenu
+
 func _process(_delta: float) -> void:
 	if Input.is_action_pressed("pause"):
-		GameStateEvents.SHOW_MENU_REQUESTED.emit("pause_menu")
+		GameStateEvents.SHOW_MENU_REQUESTED.emit(pause_menu)

--- a/demo-game/game-logic/game_manager.tscn
+++ b/demo-game/game-logic/game_manager.tscn
@@ -1,33 +1,35 @@
-[gd_scene load_steps=11 format=3 uid="uid://d0lsxr16kke5f"]
+[gd_scene load_steps=10 format=3 uid="uid://d0lsxr16kke5f"]
 
 [ext_resource type="PackedScene" uid="uid://dl8aqq8sxkssu" path="res://addons/brennys-game-manager/abstract_game_manager.tscn" id="1_ljt67"]
 [ext_resource type="Script" uid="uid://dw03336mh8qq7" path="res://addons/brennys-game-manager/level/level_key.gd" id="2_rnv0k"]
 [ext_resource type="PackedScene" uid="uid://d2evvcohqktdy" path="res://demo-game/game-logic/player/player.tscn" id="3_117uc"]
 [ext_resource type="Resource" uid="uid://i1i5a0is4d7w" path="res://demo-game/game-logic/levels/test_level.tres" id="3_ui180"]
 [ext_resource type="Resource" uid="uid://ce2nyotbnxdgd" path="res://demo-game/game-logic/levels/brown_house_interior.tres" id="4_ui180"]
-[ext_resource type="Script" uid="uid://ce1rjpku2o4uc" path="res://addons/brennys-game-manager/menu/menu_key.gd" id="5_hhprh"]
-[ext_resource type="Resource" uid="uid://bbw12tu2mmhyk" path="res://demo-game/game-logic/ui/main_menu.tres" id="6_ek1rx"]
 [ext_resource type="PackedScene" uid="uid://cn4sgft78dnqf" path="res://demo-game/game-logic/ui/pause_menu.tscn" id="7_5xvle"]
 [ext_resource type="PackedScene" uid="uid://bwu6aem7oxdx5" path="res://demo-game/game-logic/game_event_input_manager.tscn" id="8_ek1rx"]
+[ext_resource type="Script" uid="uid://ognr2qt80kba" path="res://demo-game/game-logic/menu_container.gd" id="8_upoh3"]
+[ext_resource type="PackedScene" uid="uid://bnkaobyaek6jb" path="res://demo-game/game-logic/ui/main_menu.tscn" id="9_5lud1"]
 
-[sub_resource type="Resource" id="Resource_upoh3"]
-script = ExtResource("5_hhprh")
-menuName = "pause_menu"
-targetScene = ExtResource("7_5xvle")
-metadata/_custom_type_script = "uid://ce1rjpku2o4uc"
-
-[node name="AbstractGameManager" node_paths=PackedStringArray("level_container", "menu_container", "transition_container", "player") instance=ExtResource("1_ljt67")]
+[node name="AbstractGameManager" node_paths=PackedStringArray("level_container", "menu_container", "transition_container", "player", "main_menu") instance=ExtResource("1_ljt67")]
 level_container = NodePath("LevelContainer")
 menu_container = NodePath("MenuContainer")
 transition_container = NodePath("TransitionContainer")
 player = NodePath("Player")
-main_menu = "main_menu"
+main_menu = NodePath("MenuContainer/MainMenu")
 levels = Array[ExtResource("2_rnv0k")]([ExtResource("3_ui180"), ExtResource("4_ui180")])
-menus = Array[ExtResource("5_hhprh")]([ExtResource("6_ek1rx"), SubResource("Resource_upoh3")])
 
 [node name="LevelContainer" type="Node2D" parent="." index="0"]
 
 [node name="MenuContainer" type="CanvasLayer" parent="." index="1"]
+script = ExtResource("8_upoh3")
+
+[node name="MainMenu" parent="MenuContainer" index="0" instance=ExtResource("9_5lud1")]
+visible = false
+menu_name = &"main_menu"
+
+[node name="PauseMenu" parent="MenuContainer" index="1" instance=ExtResource("7_5xvle")]
+visible = false
+menu_name = &"pause_menu"
 
 [node name="TransitionContainer" type="CanvasLayer" parent="." index="2"]
 
@@ -35,4 +37,5 @@ menus = Array[ExtResource("5_hhprh")]([ExtResource("6_ek1rx"), SubResource("Reso
 z_index = 15
 position = Vector2(576, 325)
 
-[node name="GameEventInputManager" parent="." index="4" instance=ExtResource("8_ek1rx")]
+[node name="GameEventInputManager" parent="." index="4" node_paths=PackedStringArray("pause_menu") instance=ExtResource("8_ek1rx")]
+pause_menu = NodePath("../MenuContainer/PauseMenu")

--- a/demo-game/game-logic/menu_container.gd
+++ b/demo-game/game-logic/menu_container.gd
@@ -1,0 +1,10 @@
+@tool
+extends CanvasLayer
+class_name MenuContainer
+
+func _ready():
+	map_menus()
+	
+func map_menus():
+	for menu : AbstractMenu in get_children():
+		AbstractGameManager.menu_map.set(menu.menu_name, menu)

--- a/demo-game/game-logic/menu_container.gd.uid
+++ b/demo-game/game-logic/menu_container.gd.uid
@@ -1,0 +1,1 @@
+uid://ognr2qt80kba

--- a/demo-game/game-logic/ui/main_menu.gd
+++ b/demo-game/game-logic/ui/main_menu.gd
@@ -1,7 +1,5 @@
 extends AbstractMenu
 
-@export var menu_name : StringName
-
 func _on_quit_button_pressed() -> void:
 	get_tree().quit(0)
 

--- a/demo-game/game-logic/ui/main_menu.gd
+++ b/demo-game/game-logic/ui/main_menu.gd
@@ -1,10 +1,9 @@
 extends AbstractMenu
 
-
+@export var menu_name : StringName
 
 func _on_quit_button_pressed() -> void:
 	get_tree().quit(0)
-
 
 func _on_play_button_pressed() -> void:
 	GameStateEvents.LEVEL_CHANGE_REQUESTED.emit("test_level", "fade_to_black", "default")

--- a/demo-game/game-logic/ui/pause_menu.gd
+++ b/demo-game/game-logic/ui/pause_menu.gd
@@ -1,8 +1,9 @@
 extends AbstractMenu
 
+@export var menu_name : StringName
+
 func _on_resume_button_pressed() -> void:
 	GameStateEvents.CLOSE_MENU_REQUESTED.emit()
-
 
 func _on_quit_button_pressed() -> void:
 	get_tree().quit(0)

--- a/demo-game/game-logic/ui/pause_menu.gd
+++ b/demo-game/game-logic/ui/pause_menu.gd
@@ -1,7 +1,5 @@
 extends AbstractMenu
 
-@export var menu_name : StringName
-
 func _on_resume_button_pressed() -> void:
 	GameStateEvents.CLOSE_MENU_REQUESTED.emit()
 

--- a/demo-game/game-logic/ui/pause_menu.tscn
+++ b/demo-game/game-logic/ui/pause_menu.tscn
@@ -4,20 +4,21 @@
 
 [node name="PauseMenu" type="Control"]
 layout_mode = 3
-anchors_preset = 8
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_3jee3")
 metadata/_custom_type_script = "uid://bxnyjne0oltx4"
 
 [node name="CenterContainer" type="CenterContainer" parent="."]
-layout_mode = 0
-offset_right = 40.0
-offset_bottom = 40.0
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 
 [node name="VBoxContainer" type="VBoxContainer" parent="CenterContainer"]
 layout_mode = 2


### PR DESCRIPTION
This refactor POC is to prove out a concept I'm interested in refactoring towards.

Right now, the logic in `AbstractGameManager` is tightly opinionated and the setup behavior relies on abstract keys and values declared in a resource. This refactor takes the menu setup functions out of the game manger and re-imagines them as their own controllers.

They now communicate with the `AbstractGameManager` class but allow themselves to be directly passed to the various event handlers and game dictionaries contained within the managers logic `.gd` files.

Overall this POC aims to display how we could make our abstract utility nodes in charge of their own communication to the GameManager and supports scene tree composition as opposed to resource based setup.